### PR TITLE
Return fields[0] instead of an empty string as a bad metric key

### DIFF
--- a/carbon20/validate.go
+++ b/carbon20/validate.go
@@ -221,17 +221,17 @@ func ValidatePacket(buf []byte, levelLegacy ValidationLevelLegacy, levelM20 Vali
 		err = ValidateKeyM20NoEqualsB(fields[0], levelM20)
 	}
 	if err != nil {
-		return empty, 0, 0, err
+		return fields[0], 0, 0, err
 	}
 
 	val, err := strconv.ParseFloat(string(fields[1]), 32)
 	if err != nil {
-		return empty, 0, 0, errValNotNumber
+		return fields[0], 0, 0, errValNotNumber
 	}
 
 	ts, err := strconv.ParseUint(string(fields[2]), 10, 0)
 	if err != nil {
-		return empty, 0, 0, errTsNotTs
+		return fields[0], 0, 0, errTsNotTs
 	}
 
 	return fields[0], val, uint32(ts), nil


### PR DESCRIPTION
Return fields[0] instead of an empty string as a bad metric key since we've confirmed [at this point](https://github.com/metrics20/go-metrics20/blob/master/carbon20/validate.go#L210) that we have exactly 3 fields.